### PR TITLE
[Fix] 그룹명 길이에 따른 동적 width로 수정 (#60)

### DIFF
--- a/ThunderRing/ThunderRing/Sources/Alarm/Cells/TVC/AlarmTVC.swift
+++ b/ThunderRing/ThunderRing/Sources/Alarm/Cells/TVC/AlarmTVC.swift
@@ -13,7 +13,10 @@ final class AlarmTVC: UITableViewCell {
     // MARK: - Properties
     
     @IBOutlet weak var backView: UIView!
+
+    @IBOutlet weak var hashTagBackViewWidth: NSLayoutConstraint!
     
+    @IBOutlet weak var hashTagBackView: UIView!
     @IBOutlet weak var hashTagLabel: UILabel!
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var descriptionLabel: UILabel!
@@ -30,6 +33,7 @@ final class AlarmTVC: UITableViewCell {
     
     private func configUI() {
         backView.initViewBorder(borderWidth: 1, borderColor: UIColor.gray350.cgColor, cornerRadius: 12, bounds: true)
+        hashTagBackView.initViewBorder(borderWidth: 1, borderColor: UIColor.purple100.cgColor, cornerRadius: 9.5, bounds: true)
     }
     
     // MARK: - Custom Method
@@ -39,6 +43,10 @@ final class AlarmTVC: UITableViewCell {
         titleLabel.text = title
         descriptionLabel.text = description
         timeLabel.text = time
+        
+        hashTagBackViewWidth.constant = calculateCellWidth(text: hashTag)
+        print("📌", hashTagBackViewWidth.constant)
+        contentView.layoutSubviews()
         
         switch alarmType {
         case .thunder:
@@ -55,5 +63,13 @@ final class AlarmTVC: UITableViewCell {
             }
         }
         markImageView.contentMode = .scaleAspectFill
+    }
+    
+    private func calculateCellWidth(text: String) -> CGFloat {
+        let label = UILabel()
+        label.text = text
+        label.font = .SpoqaHanSansNeo(type: .regular, size: 12)
+        label.sizeToFit()
+        return label.frame.width + 16
     }
 }

--- a/ThunderRing/ThunderRing/Sources/Alarm/Cells/TVC/AlarmTVC.xib
+++ b/ThunderRing/ThunderRing/Sources/Alarm/Cells/TVC/AlarmTVC.xib
@@ -29,20 +29,14 @@
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="N5s-OA-6uR">
                         <rect key="frame" x="25" y="8" width="285" height="109"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tSZ-yJ-7ed">
-                                <rect key="frame" x="20" y="17" width="31" height="15.5"/>
-                                <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="12"/>
-                                <color key="textColor" name="purple100"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fh8-dB-5vi">
-                                <rect key="frame" x="20" y="40.5" width="47" height="23"/>
+                                <rect key="frame" x="20" y="44" width="47" height="23"/>
                                 <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Medium" family="Spoqa Han Sans Neo" pointSize="18"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ut7-2s-grd">
-                                <rect key="frame" x="20" y="69.5" width="36" height="18"/>
+                                <rect key="frame" x="20" y="73" width="36" height="18"/>
                                 <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="14"/>
                                 <color key="textColor" name="gray100"/>
                                 <nil key="highlightedColor"/>
@@ -53,15 +47,34 @@
                                 <color key="textColor" name="grayTextNonInput"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="I5u-mG-WRv">
+                                <rect key="frame" x="20" y="17" width="50" height="19"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tSZ-yJ-7ed">
+                                        <rect key="frame" x="9.5" y="2" width="31" height="15"/>
+                                        <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="12"/>
+                                        <color key="textColor" name="purple100"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstItem="tSZ-yJ-7ed" firstAttribute="top" secondItem="I5u-mG-WRv" secondAttribute="top" constant="2" id="2KQ-TT-5mS"/>
+                                    <constraint firstAttribute="bottom" secondItem="tSZ-yJ-7ed" secondAttribute="bottom" constant="2" id="Exq-OF-qeu"/>
+                                    <constraint firstItem="tSZ-yJ-7ed" firstAttribute="centerX" secondItem="I5u-mG-WRv" secondAttribute="centerX" id="TVY-OS-2Cc"/>
+                                    <constraint firstAttribute="height" constant="19" id="df3-0X-3WG"/>
+                                    <constraint firstAttribute="width" constant="50" id="pJP-HD-eUl"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="Fh8-dB-5vi" firstAttribute="top" secondItem="tSZ-yJ-7ed" secondAttribute="bottom" constant="8" id="55p-U4-UkU"/>
-                            <constraint firstItem="tSZ-yJ-7ed" firstAttribute="top" secondItem="N5s-OA-6uR" secondAttribute="top" constant="17" id="FEs-2V-dXv"/>
+                            <constraint firstItem="Fh8-dB-5vi" firstAttribute="top" secondItem="I5u-mG-WRv" secondAttribute="bottom" constant="8" id="01m-Ul-uej"/>
                             <constraint firstAttribute="bottom" secondItem="bFP-eG-ErE" secondAttribute="bottom" constant="18" id="JAn-ye-YZx"/>
+                            <constraint firstItem="I5u-mG-WRv" firstAttribute="leading" secondItem="N5s-OA-6uR" secondAttribute="leading" constant="20" id="NRg-ta-ZpR"/>
                             <constraint firstItem="ut7-2s-grd" firstAttribute="leading" secondItem="N5s-OA-6uR" secondAttribute="leading" constant="20" id="Sfw-62-bw8"/>
-                            <constraint firstItem="tSZ-yJ-7ed" firstAttribute="leading" secondItem="N5s-OA-6uR" secondAttribute="leading" constant="20" id="cSd-rN-kJV"/>
                             <constraint firstItem="ut7-2s-grd" firstAttribute="top" secondItem="Fh8-dB-5vi" secondAttribute="bottom" constant="6" id="haL-5E-A0q"/>
+                            <constraint firstItem="I5u-mG-WRv" firstAttribute="top" secondItem="N5s-OA-6uR" secondAttribute="top" constant="17" id="iAf-YT-veN"/>
                             <constraint firstItem="Fh8-dB-5vi" firstAttribute="leading" secondItem="N5s-OA-6uR" secondAttribute="leading" constant="20" id="rCH-tN-MGs"/>
                             <constraint firstAttribute="trailing" secondItem="bFP-eG-ErE" secondAttribute="trailing" constant="20" id="zdH-Ms-eSr"/>
                         </constraints>
@@ -88,6 +101,8 @@
             <connections>
                 <outlet property="backView" destination="N5s-OA-6uR" id="5gw-rh-gGr"/>
                 <outlet property="descriptionLabel" destination="ut7-2s-grd" id="oSX-s1-xqD"/>
+                <outlet property="hashTagBackView" destination="I5u-mG-WRv" id="Zad-OD-jZp"/>
+                <outlet property="hashTagBackViewWidth" destination="pJP-HD-eUl" id="BA8-NU-Mp4"/>
                 <outlet property="hashTagLabel" destination="tSZ-yJ-7ed" id="2cK-jh-fz1"/>
                 <outlet property="markImageView" destination="Wpk-Q4-EKb" id="7um-QG-fhS"/>
                 <outlet property="timeLabel" destination="bFP-eG-ErE" id="RAw-Lx-a8m"/>


### PR DESCRIPTION
### 관련 이슈
#60 

### 구현/변경 사항 및 이유
알람 UI의 셀 - 그룹명 길이에 따라 해시태그 라벨의 width값 다르게 구현 

### PR Point
UIView + UILabel로 해시태그 라벨 구현했습니다.
text 길이에 따라서 좌우 여백 값을 더한 함수를 통해 길이를 반환하고 해당 길이값으로 가로값을 업데이트 했습니다. 

