### PR TITLE
그룹 검색 UI 구현 (Base 및 Empty 상황일 때)

### DIFF
--- a/ThunderRing/ThunderRing.xcodeproj/project.pbxproj
+++ b/ThunderRing/ThunderRing.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		92270D742750E1EB00364F3A /* AlarmDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92270D732750E1EB00364F3A /* AlarmDataModel.swift */; };
 		92275FE827BE713E007B507D /* TestVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92275FE727BE713E007B507D /* TestVC.swift */; };
 		92291C522759130F0012927B /* CompleteCreatePrivateVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92291C512759130F0012927B /* CompleteCreatePrivateVC.swift */; };
+		9240852A27CA91460029E753 /* SearchPrivateGroupVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9240852927CA91460029E753 /* SearchPrivateGroupVC.swift */; };
+		9240852C27CA97C50029E753 /* SearchPublicGroupVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9240852B27CA97C50029E753 /* SearchPublicGroupVC.swift */; };
 		9244097827AE68EB00034510 /* CreatePublicVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9244097727AE68EB00034510 /* CreatePublicVC.swift */; };
 		9244097A27AE7F9000034510 /* CompleteCreatePublicVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9244097927AE7F9000034510 /* CompleteCreatePublicVC.swift */; };
 		9251955F27CA15E900C00E7E /* SearchBaseVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9251955E27CA15E900C00E7E /* SearchBaseVC.swift */; };
@@ -156,6 +158,8 @@
 		92270D732750E1EB00364F3A /* AlarmDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmDataModel.swift; sourceTree = "<group>"; };
 		92275FE727BE713E007B507D /* TestVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestVC.swift; sourceTree = "<group>"; };
 		92291C512759130F0012927B /* CompleteCreatePrivateVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteCreatePrivateVC.swift; sourceTree = "<group>"; };
+		9240852927CA91460029E753 /* SearchPrivateGroupVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchPrivateGroupVC.swift; sourceTree = "<group>"; };
+		9240852B27CA97C50029E753 /* SearchPublicGroupVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchPublicGroupVC.swift; sourceTree = "<group>"; };
 		9244097727AE68EB00034510 /* CreatePublicVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePublicVC.swift; sourceTree = "<group>"; };
 		9244097927AE7F9000034510 /* CompleteCreatePublicVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteCreatePublicVC.swift; sourceTree = "<group>"; };
 		9251955E27CA15E900C00E7E /* SearchBaseVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBaseVC.swift; sourceTree = "<group>"; };
@@ -450,6 +454,7 @@
 			isa = PBXGroup;
 			children = (
 				92B156892761426300939048 /* MyPublicVC.swift */,
+				9240852B27CA97C50029E753 /* SearchPublicGroupVC.swift */,
 			);
 			path = MyPublic;
 			sourceTree = "<group>";
@@ -761,6 +766,7 @@
 			isa = PBXGroup;
 			children = (
 				928FDA0A2760D1B5009AC059 /* MyPrivateVC.swift */,
+				9240852927CA91460029E753 /* SearchPrivateGroupVC.swift */,
 			);
 			path = MyPrivate;
 			sourceTree = "<group>";
@@ -1207,6 +1213,8 @@
 				92CBCE79273B233F00A3F36D /* AlarmTVC.swift in Sources */,
 				92A5B2A72739AAA0004149B2 /* LogOutTVC.swift in Sources */,
 				92FF59B0275AB15000916189 /* MemberTVC.swift in Sources */,
+				9240852A27CA91460029E753 /* SearchPrivateGroupVC.swift in Sources */,
+				9240852C27CA97C50029E753 /* SearchPublicGroupVC.swift in Sources */,
 				92A5B29127398366004149B2 /* Storyboard.swift in Sources */,
 				9276B06E275B462900915F57 /* ChatDataModel.swift in Sources */,
 				9252EB952769CA9100809FEA /* ContactDataModel.swift in Sources */,

--- a/ThunderRing/ThunderRing.xcodeproj/project.pbxproj
+++ b/ThunderRing/ThunderRing.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		92291C522759130F0012927B /* CompleteCreatePrivateVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92291C512759130F0012927B /* CompleteCreatePrivateVC.swift */; };
 		9244097827AE68EB00034510 /* CreatePublicVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9244097727AE68EB00034510 /* CreatePublicVC.swift */; };
 		9244097A27AE7F9000034510 /* CompleteCreatePublicVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9244097927AE7F9000034510 /* CompleteCreatePublicVC.swift */; };
+		9251955F27CA15E900C00E7E /* SearchBaseVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9251955E27CA15E900C00E7E /* SearchBaseVC.swift */; };
 		9252EB952769CA9100809FEA /* ContactDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9252EB942769CA9100809FEA /* ContactDataModel.swift */; };
 		9252EB97276A159F00809FEA /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9252EB96276A159F00809FEA /* UIImage+.swift */; };
 		9258354E275C997900F64DC0 /* AccountInfo.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9258354D275C997900F64DC0 /* AccountInfo.storyboard */; };
@@ -157,6 +158,7 @@
 		92291C512759130F0012927B /* CompleteCreatePrivateVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteCreatePrivateVC.swift; sourceTree = "<group>"; };
 		9244097727AE68EB00034510 /* CreatePublicVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePublicVC.swift; sourceTree = "<group>"; };
 		9244097927AE7F9000034510 /* CompleteCreatePublicVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteCreatePublicVC.swift; sourceTree = "<group>"; };
+		9251955E27CA15E900C00E7E /* SearchBaseVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBaseVC.swift; sourceTree = "<group>"; };
 		9252EB942769CA9100809FEA /* ContactDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactDataModel.swift; sourceTree = "<group>"; };
 		9252EB96276A159F00809FEA /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		9258354D275C997900F64DC0 /* AccountInfo.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = AccountInfo.storyboard; sourceTree = "<group>"; };
@@ -721,6 +723,7 @@
 				926C7C5C2738043D0020F851 /* TabBarController.swift */,
 				926C7C61273805B70020F851 /* NavigationController.swift */,
 				92DD9FBB274C11710045C8C7 /* ModalNavigationController.swift */,
+				9251955E27CA15E900C00E7E /* SearchBaseVC.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -1175,6 +1178,7 @@
 				926290E427A4055E006A3B58 /* CreatePublicDetailVC.swift in Sources */,
 				9244097A27AE7F9000034510 /* CompleteCreatePublicVC.swift in Sources */,
 				92B1568A2761426300939048 /* MyPublicVC.swift in Sources */,
+				9251955F27CA15E900C00E7E /* SearchBaseVC.swift in Sources */,
 				926C7C62273805B70020F851 /* NavigationController.swift in Sources */,
 				92CBCE6F273B12EC00A3F36D /* CompleteCVC.swift in Sources */,
 				92AFB39F27633A1E00977712 /* MyGroupTVC.swift in Sources */,

--- a/ThunderRing/ThunderRing/Global/Classes/CustomNavigationBar.swift
+++ b/ThunderRing/ThunderRing/Global/Classes/CustomNavigationBar.swift
@@ -7,6 +7,9 @@
 
 import UIKit
 
+import SnapKit
+import Then
+
 class CustomNavigationBar: UIView {
     
     // MARK: - Properties
@@ -24,19 +27,13 @@ class CustomNavigationBar: UIView {
         return label
     }()
     
-//    let separatorView: UIView = {
-//        let view = UIView()
-//        view.backgroundColor = .gray
-//        return view
-//    }()
-    
     private let closeButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(named: "icnClose"), for: .normal)
         return button
     }()
     
-    // MARK: - Methods
+    // MARK: - Initializer
     
     init(vc: UIViewController, title: String, backBtnIsHidden: Bool, closeBtnIsHidden: Bool, bgColor: UIColor) {
         super.init(frame: .zero)
@@ -53,36 +50,31 @@ class CustomNavigationBar: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // MARK: - InitUI
+    
     private func initUI(bgColor: UIColor) {
         self.backgroundColor = bgColor
     }
     
     private func initLayout() {
-        addSubview(backButton)
-        addSubview(titleLabel)
-//        addSubview(separatorView)
-        addSubview(closeButton)
+        addSubviews([backButton, titleLabel, closeButton])
         
-        backButton.translatesAutoresizingMaskIntoConstraints = false
-        titleLabel.translatesAutoresizingMaskIntoConstraints = false
-//        separatorView.translatesAutoresizingMaskIntoConstraints = false
-        closeButton.translatesAutoresizingMaskIntoConstraints = false
+        backButton.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(7)
+            $0.width.height.equalTo(48)
+            $0.centerY.equalTo(titleLabel.snp.centerY)
+        }
         
-        NSLayoutConstraint.activate([
-            backButton.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-            backButton.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 7),
-            
-            titleLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-            titleLabel.centerXAnchor.constraint(equalTo: self.centerXAnchor),
-            
-//            separatorView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-//            separatorView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-//            separatorView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
-//            separatorView.heightAnchor.constraint(equalToConstant: 0.5)
-            
-            closeButton.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-            closeButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -9),
-        ])
+        titleLabel.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(15.5)
+        }
+        
+        closeButton.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(9)
+            $0.width.height.equalTo(48)
+            $0.centerY.equalTo(titleLabel.snp.centerY)
+        }
     }
     
     private func initTitle(title: String) {
@@ -107,5 +99,11 @@ class CustomNavigationBar: UIView {
     
     private func initCloseButton(closeBtnIsHidden: Bool) {
         closeButton.isHidden = closeBtnIsHidden
+    }
+    
+    // MARK: - Public Method
+    
+    public func setTitle(title: String) {
+        self.titleLabel.text = title
     }
 }

--- a/ThunderRing/ThunderRing/Global/DesignSystem/TDSButton.swift
+++ b/ThunderRing/ThunderRing/Global/DesignSystem/TDSButton.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-final class BDSButton: UIButton {
+final class TDSButton: UIButton {
     
     // MARK: - Properties
     

--- a/ThunderRing/ThunderRing/Global/DesignSystem/TDSTextField.swift
+++ b/ThunderRing/ThunderRing/Global/DesignSystem/TDSTextField.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-class BDSTextField: UITextField {
+class TDSTextField: UITextField {
     
     // MARK: - Properties
     
@@ -36,16 +36,20 @@ class BDSTextField: UITextField {
     
     private func setDefaultStyle() {
         self.font = .SpoqaHanSansNeo(type: .regular, size: 16)
-        self.setLeftPaddingPoints(15)
-        self.setRightPaddingPoints(15)
         self.backgroundColor = .white
         self.tintColor = .purple100
-        self.borderStyle = .none
+        self.layer.borderColor = UIColor.gray300.cgColor
+        self.layer.borderWidth = 1
+        self.layer.cornerRadius = 10
     }
     
     // MARK: - Public Method
     
     public func setPlaceholder(placeholder: String) {
         self.placeholder = placeholder
+    }
+    
+    public func setTintColor(tintColor: UIColor) {
+        self.tintColor = tintColor
     }
 }

--- a/ThunderRing/ThunderRing/Sources/Base/Controllers/SearchBaseVC.swift
+++ b/ThunderRing/ThunderRing/Sources/Base/Controllers/SearchBaseVC.swift
@@ -10,12 +10,29 @@ import UIKit
 import SnapKit
 import Then
 
-final class SearchBaseVC: UIViewController {
+class SearchBaseVC: UIViewController {
 
     // MARK: - Properties
     
-    private lazy var navigationBarView = CustomNavigationBar(vc: self, title: "", backBtnIsHidden: true, closeBtnIsHidden: false, bgColor: .background)
+    lazy var navigationBarView = CustomNavigationBar(vc: self, title: "title", backBtnIsHidden: true, closeBtnIsHidden: false, bgColor: .background)
+
+    private var searchBar = TDSTextField()
     
+    private var titleLabel = UILabel().then {
+        $0.text = "최근 검색"
+        $0.font = .SpoqaHanSansNeo(type: .medium, size: 18)
+    }
+    
+    private var deleteAllButton = UIButton().then {
+        $0.setTitle("전체 삭제", for: .normal)
+        $0.setTitleColor(.gray100, for: .normal)
+        $0.titleLabel?.font = .SpoqaHanSansNeo(type: .regular, size: 16)
+    }
+    
+    private var emptyLabel = UILabel().then {
+        $0.text = "검색한 기록이 없습니다."
+        $0.textColor = .gray150
+    }
     
     // MARK: - Life Cycle
     
@@ -28,13 +45,45 @@ final class SearchBaseVC: UIViewController {
     // MARK: - InitUI
     
     private func configUI() {
-        view.backgroundColor = .white
+        view.backgroundColor = .background
+        
+        view.addSubviews([navigationBarView, searchBar, titleLabel, deleteAllButton, emptyLabel])
+        
+        setStatusBar(.white)
+        navigationBarView.backgroundColor = .white
+        navigationBarView.layer.applyShadow()
+        
+        guard let image = UIImage(named: "icnSearch") else { return }
+        searchBar.setLeftIcon(16, 15, image)
+        
+        searchBar.setPlaceholder(placeholder: "그룹 명을 검색해보세요")
     }
     
     private func setLayout() {
+        navigationBarView.snp.makeConstraints {
+            $0.leading.trailing.top.equalTo(view.safeAreaLayoutGuide)
+            $0.height.equalTo(50)
+        }
         
+        searchBar.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(26)
+            $0.top.equalTo(navigationBarView.snp.bottom).offset(21)
+            $0.height.equalTo(56)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(searchBar.snp.bottom).offset(35)
+            $0.leading.equalToSuperview().inset(25)
+        }
+        
+        deleteAllButton.snp.makeConstraints {
+            $0.centerY.equalTo(titleLabel.snp.centerY)
+            $0.trailing.equalToSuperview().inset(25)
+        }
+        
+        emptyLabel.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(37)
+            $0.leading.equalToSuperview().inset(25)
+        }
     }
-    
-    // MARK: - Custom Method
-
 }

--- a/ThunderRing/ThunderRing/Sources/Base/Controllers/SearchBaseVC.swift
+++ b/ThunderRing/ThunderRing/Sources/Base/Controllers/SearchBaseVC.swift
@@ -1,0 +1,40 @@
+//
+//  SearchBaseVC.swift
+//  ThunderRing
+//
+//  Created by soyeon on 2022/02/26.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class SearchBaseVC: UIViewController {
+
+    // MARK: - Properties
+    
+    private lazy var navigationBarView = CustomNavigationBar(vc: self, title: "", backBtnIsHidden: true, closeBtnIsHidden: false, bgColor: .background)
+    
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configUI()
+        setLayout()
+    }
+    
+    // MARK: - InitUI
+    
+    private func configUI() {
+        view.backgroundColor = .white
+    }
+    
+    private func setLayout() {
+        
+    }
+    
+    // MARK: - Custom Method
+
+}

--- a/ThunderRing/ThunderRing/Sources/PrivateGroup/VCs/MyPrivate/MyPrivateVC.swift
+++ b/ThunderRing/ThunderRing/Sources/PrivateGroup/VCs/MyPrivate/MyPrivateVC.swift
@@ -93,7 +93,9 @@ extension MyPrivateVC {
         }), for: .touchUpInside)
         
         searchButton.addAction(UIAction(handler: { _ in
-            // 검색 화면으로 이동
+            let dvc = SearchPrivateGroupVC()
+            dvc.modalPresentationStyle = .fullScreen
+            self.present(dvc, animated: true, completion: nil)
         }), for: .touchUpInside)
     }
 }

--- a/ThunderRing/ThunderRing/Sources/PrivateGroup/VCs/MyPrivate/SearchPrivateGroupVC.swift
+++ b/ThunderRing/ThunderRing/Sources/PrivateGroup/VCs/MyPrivate/SearchPrivateGroupVC.swift
@@ -1,0 +1,39 @@
+//
+//  SearchPrivateGroupVC.swift
+//  ThunderRing
+//
+//  Created by soyeon on 2022/02/27.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class SearchPrivateGroupVC: SearchBaseVC {
+
+    // MARK: - Properties
+    
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configUI()
+        setLayout()
+    }
+    
+    // MARK: - InitUI
+    
+    private func configUI() {
+        view.backgroundColor = .white
+        
+        navigationBarView.setTitle(title: "비공개 그룹")
+    }
+    
+    private func setLayout() {
+        
+    }
+    
+    // MARK: - Custom Method
+}

--- a/ThunderRing/ThunderRing/Sources/PublicGroup/VCs/MyPublic/MyPublicVC.swift
+++ b/ThunderRing/ThunderRing/Sources/PublicGroup/VCs/MyPublic/MyPublicVC.swift
@@ -79,7 +79,9 @@ extension MyPublicVC {
         }), for: .touchUpInside)
         
         searchButton.addAction(UIAction(handler: { _ in
-            // search 화면으로 이동
+            let dvc = SearchPublicGroupVC()
+            dvc.modalPresentationStyle = .fullScreen
+            self.present(dvc, animated: true, completion: nil)
         }), for: .touchUpInside)
     }
 }

--- a/ThunderRing/ThunderRing/Sources/PublicGroup/VCs/MyPublic/SearchPublicGroupVC.swift
+++ b/ThunderRing/ThunderRing/Sources/PublicGroup/VCs/MyPublic/SearchPublicGroupVC.swift
@@ -1,0 +1,39 @@
+//
+//  SearchPublicGroupVC.swift
+//  ThunderRing
+//
+//  Created by soyeon on 2022/02/27.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class SearchPublicGroupVC: SearchBaseVC {
+
+    // MARK: - Properties
+    
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configUI()
+        setLayout()
+    }
+    
+    // MARK: - InitUI
+    
+    private func configUI() {
+        view.backgroundColor = .white
+        
+        navigationBarView.setTitle(title: "공개 그룹")
+    }
+    
+    private func setLayout() {
+        
+    }
+    
+    // MARK: - Custom Method
+}


### PR DESCRIPTION
### 관련 이슈
#71 

### 구현/변경 사항 및 이유
비공개 그룹, 공개 그룹의 검색 UI를 구현했습니다. 두 화면의 기본적인 틀이 같기 때문에 Base View Controller로 Empty뷰를 제작하였고 그룹 모아보기 화면에서 검색 버튼을 누르면 각각의 검색 화면으로 이동하도록 구현했습니다. 

### PR Point
두 검색의 UI가 비슷하여 Base View Controller를 만들어 이를 상속하는 방식으로 화면을 구현했습니다.

