### PR TITLE
[Mod] TDS 네비게이션 구현 (#73)

### DIFF
--- a/ThunderRing/ThunderRing.xcodeproj/project.pbxproj
+++ b/ThunderRing/ThunderRing.xcodeproj/project.pbxproj
@@ -34,6 +34,10 @@
 		9240852C27CA97C50029E753 /* SearchPublicGroupVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9240852B27CA97C50029E753 /* SearchPublicGroupVC.swift */; };
 		9244097827AE68EB00034510 /* CreatePublicVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9244097727AE68EB00034510 /* CreatePublicVC.swift */; };
 		9244097A27AE7F9000034510 /* CompleteCreatePublicVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9244097927AE7F9000034510 /* CompleteCreatePublicVC.swift */; };
+		9248133027D130D600A0CECC /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9248132F27D130D600A0CECC /* MainViewController.swift */; };
+		9248133227D1319C00A0CECC /* TDSNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9248133127D1319C00A0CECC /* TDSNavigationBar.swift */; };
+		9248133427D1323400A0CECC /* CloseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9248133327D1323400A0CECC /* CloseButton.swift */; };
+		9248133627D132B400A0CECC /* BackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9248133527D132B400A0CECC /* BackButton.swift */; };
 		9251955F27CA15E900C00E7E /* SearchBaseVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9251955E27CA15E900C00E7E /* SearchBaseVC.swift */; };
 		9252EB952769CA9100809FEA /* ContactDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9252EB942769CA9100809FEA /* ContactDataModel.swift */; };
 		9252EB97276A159F00809FEA /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9252EB96276A159F00809FEA /* UIImage+.swift */; };
@@ -162,6 +166,10 @@
 		9240852B27CA97C50029E753 /* SearchPublicGroupVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchPublicGroupVC.swift; sourceTree = "<group>"; };
 		9244097727AE68EB00034510 /* CreatePublicVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePublicVC.swift; sourceTree = "<group>"; };
 		9244097927AE7F9000034510 /* CompleteCreatePublicVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteCreatePublicVC.swift; sourceTree = "<group>"; };
+		9248132F27D130D600A0CECC /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
+		9248133127D1319C00A0CECC /* TDSNavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TDSNavigationBar.swift; sourceTree = "<group>"; };
+		9248133327D1323400A0CECC /* CloseButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseButton.swift; sourceTree = "<group>"; };
+		9248133527D132B400A0CECC /* BackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackButton.swift; sourceTree = "<group>"; };
 		9251955E27CA15E900C00E7E /* SearchBaseVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBaseVC.swift; sourceTree = "<group>"; };
 		9252EB942769CA9100809FEA /* ContactDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactDataModel.swift; sourceTree = "<group>"; };
 		9252EB96276A159F00809FEA /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
@@ -692,6 +700,7 @@
 				926C7C1D2737F93E0020F851 /* MainVC.swift */,
 				1DF615C52752CD8F00D0CF7C /* RecruitingVC.swift */,
 				1DA5D063275BD7A100F78579 /* JoinVC.swift */,
+				9248132F27D130D600A0CECC /* MainViewController.swift */,
 			);
 			path = VCs;
 			sourceTree = "<group>";
@@ -964,6 +973,9 @@
 			children = (
 				92E416EA27B8237900FD008F /* TDSTextField.swift */,
 				92E416EC27B824CF00FD008F /* TDSButton.swift */,
+				9248133127D1319C00A0CECC /* TDSNavigationBar.swift */,
+				9248133327D1323400A0CECC /* CloseButton.swift */,
+				9248133527D132B400A0CECC /* BackButton.swift */,
 			);
 			path = DesignSystem;
 			sourceTree = "<group>";
@@ -1175,8 +1187,10 @@
 				9276B06B275B458B00915F57 /* String+.swift in Sources */,
 				92687A5727501E5C000D9A5D /* CALayer+.swift in Sources */,
 				92F9A53F27AFF4E3004F41FE /* TempCell.swift in Sources */,
+				9248133027D130D600A0CECC /* MainViewController.swift in Sources */,
 				928AE07B276B0D4C001155EE /* PrivateGroupCVC.swift in Sources */,
 				92E416EF27B8264B00FD008F /* Adjust+.swift in Sources */,
+				9248133227D1319C00A0CECC /* TDSNavigationBar.swift in Sources */,
 				92159CA22758D76D0081F20B /* MemberCVC.swift in Sources */,
 				92A5B29F2739AA2F004149B2 /* MyPageAlarmTVC.swift in Sources */,
 				926C7C372737FB4C0020F851 /* UIView+.swift in Sources */,
@@ -1229,6 +1243,7 @@
 				925BAC482742C77C00126166 /* PublicListTVC.swift in Sources */,
 				9276B069275B457700915F57 /* UILabel+.swift in Sources */,
 				92E497762768C42E0029682C /* ChatListDataModel.swift in Sources */,
+				9248133627D132B400A0CECC /* BackButton.swift in Sources */,
 				92159C9C2758C5B10081F20B /* CreatePrivateDetailVC.swift in Sources */,
 				926C7C522738030F0020F851 /* MyPageVC.swift in Sources */,
 				928FDA0D2760D1C4009AC059 /* PrivateDetailVC.swift in Sources */,
@@ -1254,6 +1269,7 @@
 				92A5B29A27398D47004149B2 /* CustomNavigationBar.swift in Sources */,
 				92275FE827BE713E007B507D /* TestVC.swift in Sources */,
 				92F43A33274E8491006025EC /* CompleteLightningVC.swift in Sources */,
+				9248133427D1323400A0CECC /* CloseButton.swift in Sources */,
 				92A5B29727398835004149B2 /* UITabBar+.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ThunderRing/ThunderRing/Global/DesignSystem/BackButton.swift
+++ b/ThunderRing/ThunderRing/Global/DesignSystem/BackButton.swift
@@ -1,0 +1,51 @@
+//
+//  BackButton.swift
+//  ThunderRing
+//
+//  Created by soyeon on 2022/03/04.
+//
+
+import UIKit
+
+import SnapKit
+
+final class BackButton: UIButton {
+                
+    // MARK: - Initializer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configUI()
+        setupLayout()
+    }
+    
+    convenience init(root: UIViewController) {
+        self.init()
+        setupAction(vc: root)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - InitUI
+    
+    private func configUI() {
+        setImage(UIImage(named: "btnBack"), for: .normal)
+    }
+    
+    private func setupLayout() {
+        self.snp.makeConstraints { make in
+            make.width.height.equalTo(44)
+        }
+    }
+    
+    // MARK: - Custom Method
+    
+    private func setupAction(vc: UIViewController) {
+        let backAction = UIAction { action in
+            vc.navigationController?.popViewController(animated: true)
+        }
+        self.addAction(backAction, for: .touchUpInside)
+    }
+}

--- a/ThunderRing/ThunderRing/Global/DesignSystem/CloseButton.swift
+++ b/ThunderRing/ThunderRing/Global/DesignSystem/CloseButton.swift
@@ -1,0 +1,51 @@
+//
+//  BackButton.swift
+//  ThunderRing
+//
+//  Created by soyeon on 2022/03/04.
+//
+
+import UIKit
+
+import SnapKit
+
+final class CloseButton: UIButton {
+                
+    // MARK: - Initializer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configUI()
+        setupLayout()
+    }
+    
+    convenience init(root: UIViewController) {
+        self.init()
+        setupAction(vc: root)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - InitUI
+    
+    private func configUI() {
+        setImage(UIImage(named: "icnClose"), for: .normal)
+    }
+    
+    private func setupLayout() {
+        self.snp.makeConstraints { make in
+            make.width.height.equalTo(44)
+        }
+    }
+    
+    // MARK: - Custom Method
+    
+    private func setupAction(vc: UIViewController) {
+        let closeAction = UIAction { _ in
+            vc.dismiss(animated: true, completion: nil)
+        }
+        self.addAction(closeAction, for: .touchUpInside)
+    }
+}

--- a/ThunderRing/ThunderRing/Global/DesignSystem/TDSNavigationBar.swift
+++ b/ThunderRing/ThunderRing/Global/DesignSystem/TDSNavigationBar.swift
@@ -1,0 +1,145 @@
+//
+//  TDSNavigationBar.swift
+//  ThunderRing
+//
+//  Created by soyeon on 2022/03/04.
+//
+
+import Foundation
+
+import SnapKit
+import Then
+
+enum ViewType {
+
+}
+
+final class TDSNavigationBar: UIView {
+    
+    // MARK: - Metric Enum
+    
+    public enum Metric {
+        static let navigationHeight: CGFloat = 50
+        static let titleTop: CGFloat = 13
+        static let titleLeading: CGFloat = 25
+        static let buttonLeading: CGFloat = 4
+        static let buttonTrailing: CGFloat = 7
+        static let buttonSize: CGFloat = 44
+    }
+    
+    // MARK: - PageView Enum
+    
+    public enum PageView {
+        case main
+        case chat
+        case lightning
+        case alarm
+        case mypage
+        case test
+        case publicGroup
+        case privateGroup
+        
+        var title: String {
+            switch self {
+            case .main:
+                return "어쩌고"
+            case .chat:
+                return ""
+            case .lightning:
+                return "채팅"
+            case .alarm:
+                return "알람"
+            case .mypage:
+                return "마이페이지"
+            case .test:
+                return "성향테스트"
+            case .publicGroup:
+                return "공개그룹"
+            case .privateGroup:
+                return "비공개그룹"
+            }
+        }
+    }
+    
+    // MARK: - Properties
+    
+    private var viewController = UIViewController()
+    public var backButton = BackButton()
+    private var closeButton = CloseButton()
+    
+    private var titleLabel = UILabel().then {
+        $0.font = .SpoqaHanSansNeo(type: .medium, size: 20)
+        $0.textColor = .black
+        $0.textAlignment = .center
+    }
+    
+    private var viewType: PageView = .main {
+        didSet {
+            configUI()
+        }
+    }
+    
+    // MARK: - Initializer
+    
+    public init(_ viewController: UIViewController,
+                view: PageView,
+                backButtonIsHidden: Bool,
+                closeButtonIsHidden: Bool) {
+        super.init(frame: .zero)
+        self.backButton = BackButton(root: viewController)
+        self.closeButton = CloseButton(root: viewController)
+        viewType = view
+        configUI()
+        setUpLayout()
+        setUpBackButton(isHidden: backButtonIsHidden)
+        setUpCloseButton(isHidden: closeButtonIsHidden)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - InitUI
+    
+    private func configUI() {
+        backgroundColor = .white
+        titleLabel.text = viewType.title
+    }
+    
+    private func setUpLayout() {
+        addSubviews([backButton,
+                     titleLabel,
+                     closeButton])
+        
+        snp.makeConstraints { make in
+            make.height.equalTo(Metric.navigationHeight)
+        }
+        
+        backButton.snp.makeConstraints { make in
+            make.top.equalToSuperview()
+            make.leading.equalToSuperview().inset(Metric.buttonLeading)
+            make.width.height.equalTo(Metric.buttonSize)
+        }
+        
+        titleLabel.snp.makeConstraints { make in
+            make.bottom.equalToSuperview().inset(9)
+            make.centerX.equalToSuperview()
+        }
+        
+        closeButton.snp.makeConstraints { make in
+            make.top.equalToSuperview()
+            make.trailing.equalToSuperview().inset(Metric.buttonTrailing)
+            make.width.height.equalTo(Metric.buttonSize)
+        }
+    }
+    
+    // MARK: - Custom Method
+    
+    private func setUpBackButton(isHidden: Bool) {
+        backButton.isHidden = isHidden
+    }
+    
+    private func setUpCloseButton(isHidden: Bool) {
+        closeButton.isHidden = isHidden
+    }
+}

--- a/ThunderRing/ThunderRing/Sources/Main/VCs/MainViewController.swift
+++ b/ThunderRing/ThunderRing/Sources/Main/VCs/MainViewController.swift
@@ -1,0 +1,38 @@
+//
+//  MainViewController.swift
+//  ThunderRing
+//
+//  Created by soyeon on 2022/03/04.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class MainViewController: UIViewController {
+    
+    // MARK: - Properties
+    
+    private lazy var navigationBar = TDSNavigationBar(self, view: .main, backButtonIsHidden: true, closeButtonIsHidden: true)
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configUI()
+        setLayout()
+    }
+    
+    // MARK: - InitUI
+    
+    private func configUI() {
+        view.backgroundColor = .white
+    }
+    
+    private func setLayout() {
+        
+    }
+    
+    // MARK: - Custom Method
+}


### PR DESCRIPTION
### 관련 이슈
#73 

### 구현/변경 사항 및 이유
변경된 네비게이션 높이에 따라 TDS에 네비게이션 추가 

### PR Point
화면을 ViewType을 나눠서 각 화면에 맞게 타이틀 라벨을 지정할 수 있도록 했습니다.

### 참고 사항
코드 베이스 방식에서 좀 더 이점이 있습니다. (스보베이스라면, 스토리보드에 UIView를 깔고 해당 뷰를 디자인시스템으로 만든 TDSNavigationBar로 생성하는 방법도 있습니다.)
