### PR TITLE
홈화면 UI 구현 

### DIFF
--- a/ThunderRing/ThunderRing.xcodeproj/project.pbxproj
+++ b/ThunderRing/ThunderRing.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		92609ACD274BD9A700F0E401 /* SetLigntningDetailVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92609ACC274BD9A700F0E401 /* SetLigntningDetailVC.swift */; };
 		926290E127A40543006A3B58 /* PublicDetailVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 926290E027A40543006A3B58 /* PublicDetailVC.swift */; };
 		926290E427A4055E006A3B58 /* CreatePublicDetailVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 926290E327A4055E006A3B58 /* CreatePublicDetailVC.swift */; };
+		92640F9F27D678B800E71CBD /* HomeHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92640F9E27D678B800E71CBD /* HomeHeaderView.swift */; };
 		92687A5727501E5C000D9A5D /* CALayer+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92687A5627501E5C000D9A5D /* CALayer+.swift */; };
 		926C7C1A2737F93E0020F851 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 926C7C192737F93E0020F851 /* AppDelegate.swift */; };
 		926C7C1C2737F93E0020F851 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 926C7C1B2737F93E0020F851 /* SceneDelegate.swift */; };
@@ -187,6 +188,7 @@
 		92609ACC274BD9A700F0E401 /* SetLigntningDetailVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetLigntningDetailVC.swift; sourceTree = "<group>"; };
 		926290E027A40543006A3B58 /* PublicDetailVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicDetailVC.swift; sourceTree = "<group>"; };
 		926290E327A4055E006A3B58 /* CreatePublicDetailVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePublicDetailVC.swift; sourceTree = "<group>"; };
+		92640F9E27D678B800E71CBD /* HomeHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeHeaderView.swift; sourceTree = "<group>"; };
 		92687A5627501E5C000D9A5D /* CALayer+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CALayer+.swift"; sourceTree = "<group>"; };
 		926C7C162737F93E0020F851 /* ThunderRing.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ThunderRing.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		926C7C192737F93E0020F851 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -419,6 +421,7 @@
 				9248133A27D13B8E00A0CECC /* HomePrivateGroupCollectionViewCellView.swift */,
 				92B471AC27D37A3500D691E7 /* HomePublicGroupCollectionViewCell.swift */,
 				92B471AE27D3814500D691E7 /* HomePublicGroupCollectionViewCellView.swift */,
+				92640F9E27D678B800E71CBD /* HomeHeaderView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1239,6 +1242,7 @@
 				92FC851727C00E950020965A /* TestResponse.swift in Sources */,
 				92B619CF273EEF4700BE31D1 /* ChatListTVC.swift in Sources */,
 				92CBCE79273B233F00A3F36D /* AlarmTVC.swift in Sources */,
+				92640F9F27D678B800E71CBD /* HomeHeaderView.swift in Sources */,
 				92A5B2A72739AAA0004149B2 /* LogOutTVC.swift in Sources */,
 				92FF59B0275AB15000916189 /* MemberTVC.swift in Sources */,
 				9240852A27CA91460029E753 /* SearchPrivateGroupVC.swift in Sources */,

--- a/ThunderRing/ThunderRing/Global/Extensions/CALayer+.swift
+++ b/ThunderRing/ThunderRing/Global/Extensions/CALayer+.swift
@@ -10,7 +10,7 @@ import UIKit
 extension CALayer {
     func applyShadow(
         color: UIColor = .grayShadow,
-        alpha: Float = 0.7,
+        alpha: Float = 1,
         x: CGFloat = 0,
         y: CGFloat = 2,
         blur: CGFloat = 7,

--- a/ThunderRing/ThunderRing/Global/Supports/AppDelegate.swift
+++ b/ThunderRing/ThunderRing/Global/Supports/AppDelegate.swift
@@ -17,10 +17,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     let notificationCenter = UNUserNotificationCenter.current()
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // 스플래쉬 화면
+        /// 스플래쉬 화면
         sleep(1)
         
-        // 로컬 notification
+        /// 로컬 notification
         notificationCenter.delegate = self
         let options: UNAuthorizationOptions = [.alert, .sound, .badge]
         notificationCenter.requestAuthorization(options: options) {
@@ -30,7 +30,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         }
         
-        // 구글 파이어베이스 연동 
+        /// 구글 파이어베이스 연동
         FirebaseApp.configure()
         
         // FIXME: - DB 설계 후 번개 데이터 읽기 
@@ -52,7 +52,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
     
-    // iOS 13 이하 배지 초기화
+    /// iOS 13 이하 배지 초기화
     func applicationDidBecomeActive(_ application: UIApplication) {
         UIApplication.shared.applicationIconBadgeNumber = 0
     }
@@ -61,7 +61,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 // MARK: - Local Notification
 
 extension AppDelegate: UNUserNotificationCenterDelegate {
-    
     func userNotificationCenter(_ center: UNUserNotificationCenter,
                                 willPresent notification: UNNotification,
                                 withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
@@ -72,7 +71,6 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     func userNotificationCenter(_ center: UNUserNotificationCenter,
                                 didReceive response: UNNotificationResponse,
                                 withCompletionHandler completionHandler: @escaping () -> Void) {
-        print("푸시 알림 클릭 후 앱 진입")
         NotificationCenter.default.post(name: NSNotification.Name("EnterAppByPush"), object: nil)
         completionHandler()
     }

--- a/ThunderRing/ThunderRing/Global/Supports/SceneDelegate.swift
+++ b/ThunderRing/ThunderRing/Global/Supports/SceneDelegate.swift
@@ -21,7 +21,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = UIWindow(frame: windowScene.coordinateSpace.bounds)
         window?.windowScene = windowScene
         
-        window?.rootViewController = UIStoryboard(name: Const.Storyboard.Name.Main, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Name.TabBar)
+//        window?.rootViewController = UIStoryboard(name: Const.Storyboard.Name.Main, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Name.TabBar)
+        
+        window?.rootViewController = TabBarController()
         
         window?.makeKeyAndVisible()
     }

--- a/ThunderRing/ThunderRing/Sources/Base/Controllers/TabBarController.swift
+++ b/ThunderRing/ThunderRing/Sources/Base/Controllers/TabBarController.swift
@@ -21,7 +21,7 @@ final class TabBarController: UITabBarController {
     
     private func initUI() {
         UITabBar.appearance().backgroundColor = .white
-        UITabBar.appearance().tintColor = UIColor(red: 157.0 / 255.0, green: 157.0 / 255.0, blue: 157.0 / 255.0, alpha: 1.0)
+        UITabBar.appearance().tintColor = .gray150
         
         let appearance = UITabBarAppearance()
         appearance.configureWithOpaqueBackground()
@@ -31,9 +31,12 @@ final class TabBarController: UITabBarController {
     }
     
     private func setTabBar() {
-        let mainStoryboard = UIStoryboard.init(name: Const.Storyboard.Name.Main, bundle: nil)
-        let mainTab = mainStoryboard.instantiateViewController(identifier: Const.ViewController.Name.Navigation)
-        mainTab.tabBarItem = UITabBarItem(title: "홈", image: UIImage(named: "homeIn"), selectedImage: UIImage(named: "home"))
+//        let mainStoryboard = UIStoryboard.init(name: Const.Storyboard.Name.Main, bundle: nil)
+//        let mainTab = mainStoryboard.instantiateViewController(identifier: Const.ViewController.Name.Navigation)
+//        mainTab.tabBarItem = UITabBarItem(title: "홈", image: UIImage(named: "homeIn"), selectedImage: UIImage(named: "home"))
+        
+        let homeTab = HomeViewController()
+        homeTab.tabBarItem = UITabBarItem(title: "홈", image: UIImage(named: "homeIn"), selectedImage: UIImage(named: "home"))
         
         let chatStoryboard = UIStoryboard.init(name: Const.Storyboard.Name.Chat, bundle: nil)
         let chatTab = chatStoryboard.instantiateViewController(identifier: Const.ViewController.Name.Navigation)
@@ -51,10 +54,10 @@ final class TabBarController: UITabBarController {
         let myTab = myStoryboard.instantiateViewController(identifier: Const.ViewController.Name.Navigation)
         myTab.tabBarItem = UITabBarItem(title: "프로필", image: UIImage(named: "mypageIn"), selectedImage: UIImage(named: "mypage"))
         
-        let tabs =  [mainTab, chatTab, lightningTab, alarmTab, myTab]
+        let tabs =  [homeTab, chatTab, lightningTab, alarmTab, myTab]
         
         self.setViewControllers(tabs, animated: false)
-        self.selectedViewController = mainTab
+        self.selectedViewController = homeTab
     }
 }
 

--- a/ThunderRing/ThunderRing/Sources/Base/Controllers/TabBarController.swift
+++ b/ThunderRing/ThunderRing/Sources/Base/Controllers/TabBarController.swift
@@ -7,13 +7,11 @@
 
 import UIKit
 
-class TabBarController: UITabBarController {
+final class TabBarController: UITabBarController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
         self.delegate = self
-        
         initUI()
         setTabBar()
         getNotification()
@@ -35,23 +33,23 @@ class TabBarController: UITabBarController {
     private func setTabBar() {
         let mainStoryboard = UIStoryboard.init(name: Const.Storyboard.Name.Main, bundle: nil)
         let mainTab = mainStoryboard.instantiateViewController(identifier: Const.ViewController.Name.Navigation)
-        mainTab.tabBarItem = UITabBarItem(title: "", image: UIImage(named: "homeIn"), selectedImage: UIImage(named: "home"))
+        mainTab.tabBarItem = UITabBarItem(title: "홈", image: UIImage(named: "homeIn"), selectedImage: UIImage(named: "home"))
         
         let chatStoryboard = UIStoryboard.init(name: Const.Storyboard.Name.Chat, bundle: nil)
         let chatTab = chatStoryboard.instantiateViewController(identifier: Const.ViewController.Name.Navigation)
-        chatTab.tabBarItem = UITabBarItem(title: "", image: UIImage(named: "chatIn"), selectedImage: UIImage(named: "chat"))
+        chatTab.tabBarItem = UITabBarItem(title: "채팅", image: UIImage(named: "chatIn"), selectedImage: UIImage(named: "chat"))
         
         let lightningStoryboard = UIStoryboard.init(name: Const.Storyboard.Name.Lightning, bundle: nil)
         let lightningTab = lightningStoryboard.instantiateViewController(identifier: Const.ViewController.Name.ModalNavigation)
-        lightningTab.tabBarItem = UITabBarItem(title: "", image: UIImage(named: "thunder"), selectedImage: UIImage(named: "thunder"))
+        lightningTab.tabBarItem = UITabBarItem(title: "번개", image: UIImage(named: "thunder"), selectedImage: UIImage(named: "thunder"))
         
         let alarmStoryboard = UIStoryboard.init(name: Const.Storyboard.Name.Alarm, bundle: nil)
         let alarmTab = alarmStoryboard.instantiateViewController(identifier: Const.ViewController.Name.Navigation)
-        alarmTab.tabBarItem = UITabBarItem(title: "", image: UIImage(named: "alarmIn"), selectedImage: UIImage(named: "alarm"))
+        alarmTab.tabBarItem = UITabBarItem(title: "알림", image: UIImage(named: "alarmIn"), selectedImage: UIImage(named: "alarm"))
         
         let myStoryboard = UIStoryboard.init(name: Const.Storyboard.Name.MyPage, bundle: nil)
         let myTab = myStoryboard.instantiateViewController(identifier: Const.ViewController.Name.Navigation)
-        myTab.tabBarItem = UITabBarItem(title: "", image: UIImage(named: "mypageIn"), selectedImage: UIImage(named: "mypage"))
+        myTab.tabBarItem = UITabBarItem(title: "프로필", image: UIImage(named: "mypageIn"), selectedImage: UIImage(named: "mypage"))
         
         let tabs =  [mainTab, chatTab, lightningTab, alarmTab, myTab]
         
@@ -77,8 +75,7 @@ extension TabBarController {
         NotificationCenter.default.addObserver(self, selector: #selector(setSelectedTab(_:)), name: NSNotification.Name("EnterAppByPush"), object: nil)
     }
     
-    @objc
-    func setSelectedTab(_ notification: Notification) {
+    @objc func setSelectedTab(_ notification: Notification) {
         print("알람 탭으로 이동")
         self.selectedIndex = 3
     }

--- a/ThunderRing/ThunderRing/Sources/Home/VCs/HomeViewController.swift
+++ b/ThunderRing/ThunderRing/Sources/Home/VCs/HomeViewController.swift
@@ -14,27 +14,216 @@ final class HomeViewController: UIViewController {
     
     // MARK: - Properties
     
-    private lazy var navigationBar = TDSNavigationBar(self, view: .main, backButtonIsHidden: true, closeButtonIsHidden: true)
+    private lazy var navigationBar = UIView().then {
+        $0.backgroundColor = .background
+    }
+    
+    private lazy var recruitingButton = UIButton().then {
+        $0.setTitle("", for: .normal)
+        $0.setImage(UIImage(named: "btnRecruit"), for: .normal)
+    }
+    
+    private lazy var searchButton = UIButton().then {
+        $0.setTitle("", for: .normal)
+        $0.setImage(UIImage(named: "btnSearch"), for: .normal)
+        $0.tintColor = .gray100
+    }
+    
+    private lazy var topView = UIView().then {
+        $0.backgroundColor = .background
+    }
+    
+    private lazy var titleLabel = UILabel().then {
+        $0.text = "번개를 치고\n천둥을 울려보세요"
+        $0.textColor = .black
+        $0.font = .SpoqaHanSansNeo(type: .medium, size: 21)
+        $0.numberOfLines = 2
+    }
+    
+    private lazy var subTitleLabel = UILabel().then {
+        $0.text = "누구와 약속을 잡아볼까요?"
+        $0.textColor = .black
+        $0.font = .SpoqaHanSansNeo(type: .regular, size: 15)
+    }
+    
+    private lazy var contentScrollView = UIScrollView().then {
+        $0.isScrollEnabled = true
+        $0.isPagingEnabled = false
+        $0.showsVerticalScrollIndicator = false
+        $0.backgroundColor = .clear
+    }
+    
+    private lazy var contentView = UIView()
+    
+    private lazy var contentStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.distribution = .equalSpacing
+        $0.alignment = .fill
+        $0.spacing = 0
+    }
+        
+    private lazy var privateGroupHeaderView = HomeHeaderView().then {
+        $0.title = "비공개 그룹"
+        $0.count = privateGroupData.count
+    }
+    
+    private lazy var publicGroupHeaderView = HomeHeaderView().then {
+        $0.title = "공개 그룹"
+        $0.count = publicGroupData.count
+    }
+    
+    private lazy var privateGroupCollectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .horizontal
+        layout.itemSize = UICollectionViewFlowLayout.automaticSize
+        layout.estimatedItemSize = .zero
+        
+        return UICollectionView(frame: .zero, collectionViewLayout: layout).then {
+            $0.backgroundColor = .clear
+            $0.isScrollEnabled = true
+            $0.showsHorizontalScrollIndicator = false
+        }
+    }()
+    
+    private lazy var publicGroupCollectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .vertical
+        layout.itemSize = UICollectionViewFlowLayout.automaticSize
+        layout.estimatedItemSize = .zero
+        
+        return UICollectionView(frame: .zero, collectionViewLayout: layout).then {
+            $0.backgroundColor = .clear
+            $0.isScrollEnabled = false
+            $0.showsHorizontalScrollIndicator = false
+        }
+    }()
     
     // MARK: - Life Cycle
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(true)
+        navigationController?.isNavigationBarHidden = true
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         configUI()
         setLayout()
+        bind()
     }
     
     // MARK: - InitUI
     
     private func configUI() {
-        view.backgroundColor = .white
+        view.backgroundColor = .background
+
+        view.addSubviews([navigationBar, contentScrollView])
+
+        navigationBar.addSubviews([recruitingButton, searchButton])
+
+        contentScrollView.addSubview(contentView)
+
+        contentView.addSubviews([topView, contentStackView])
+        
+        topView.addSubviews([titleLabel, subTitleLabel])
+        topView.layer.applyShadow()
+        
+        [privateGroupHeaderView, privateGroupCollectionView, publicGroupHeaderView, publicGroupCollectionView].forEach {
+            contentStackView.addArrangedSubview($0)
+        }
     }
     
     private func setLayout() {
+        navigationBar.snp.makeConstraints {
+            $0.top.leading.trailing.equalTo(view.safeAreaLayoutGuide)
+            $0.height.equalTo(50)
+        }
+        
+        recruitingButton.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().inset(268)
+            $0.width.height.equalTo(48)
+        }
+        
+        searchButton.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalTo(recruitingButton.snp.trailing)
+            $0.width.height.equalTo(48)
+        }
+        
+        contentScrollView.snp.makeConstraints {
+            $0.top.equalTo(navigationBar.snp.bottom)
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
+        
+        contentView.snp.makeConstraints {
+            $0.top.leading.trailing.bottom.equalToSuperview()
+            $0.width.equalToSuperview()
+            $0.height.greaterThanOrEqualToSuperview()
+        }
+        
+        topView.snp.makeConstraints {
+            $0.top.leading.trailing.equalToSuperview()
+            $0.height.equalTo(141)
+        }
+        
+        contentStackView.snp.makeConstraints {
+            $0.top.equalTo(topView.snp.bottom)
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
+
+        titleLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(25)
+            $0.top.equalToSuperview().inset(21)
+        }
+
+        subTitleLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(25)
+            $0.top.equalTo(titleLabel.snp.bottom).offset(3)
+        }
+
+        privateGroupHeaderView.snp.makeConstraints {
+            $0.top.equalTo(topView.snp.bottom)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(67)
+        }
+
+        privateGroupCollectionView.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview()
+            $0.top.equalTo(privateGroupHeaderView.snp.bottom)
+            $0.height.equalTo(285)
+        }
+
+        // FIXME: 높이값 피그마 78 -> UIView를 추가 || 디자이너와 상의
+
+        publicGroupHeaderView.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview()
+            $0.top.equalTo(privateGroupCollectionView.snp.bottom)
+            $0.height.equalTo(67)
+        }
+
+        publicGroupCollectionView.snp.makeConstraints {
+            $0.top.equalTo(publicGroupHeaderView.snp.bottom)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(733)
+            $0.bottom.equalToSuperview()
+        }
         
     }
     
     // MARK: - Custom Method
+    
+    private func bind() {
+        privateGroupCollectionView.delegate = self
+        privateGroupCollectionView.dataSource = self
+        
+        publicGroupCollectionView.delegate = self
+        publicGroupCollectionView.dataSource = self
+
+        privateGroupCollectionView.register(HomePrivateGroupCollectionViewCell.self, forCellWithReuseIdentifier: HomePrivateGroupCollectionViewCell.CellIdentifier)
+        
+        publicGroupCollectionView.register(HomePublicGroupCollectionViewCell.self, forCellWithReuseIdentifier: HomePublicGroupCollectionViewCell.CellIdentifier)
+    }
 }
 
 // MARK: - Custom Delegate
@@ -46,5 +235,73 @@ extension HomeViewController: HomePrivateGroupCollectionViewCellViewDelegate {
     
     func touchUpLightningButton() {
         print("번개 버튼 누름")
+    }
+}
+
+// MARK: - UICollectionView Delegate
+
+extension HomeViewController: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        switch collectionView {
+        case privateGroupCollectionView:
+            let cellWidth = 298
+            let cellHeight = 285
+            return CGSize(width: cellWidth, height: cellHeight)
+        case publicGroupCollectionView:
+            let cellWidth = 158
+            let cellHeight = 227
+            return CGSize(width: cellWidth, height: cellHeight)
+        default:
+            return .zero
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
+        return 7
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return 7
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+        switch collectionView {
+        case privateGroupCollectionView:
+            return UIEdgeInsets(top: 0, left: 26, bottom: 0, right: 0)
+        case publicGroupCollectionView:
+            return UIEdgeInsets(top: 0, left: 26, bottom: 0, right: 26)
+        default:
+            return .zero
+        }
+    }
+}
+
+extension HomeViewController: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        switch collectionView {
+        case privateGroupCollectionView:
+            return privateGroupData.count / 2
+        case publicGroupCollectionView:
+            return publicGroupData.count
+        default:
+            return 0
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        switch collectionView {
+        case privateGroupCollectionView:
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: HomePrivateGroupCollectionViewCell.CellIdentifier, for: indexPath) as? HomePrivateGroupCollectionViewCell else { return UICollectionViewCell() }
+            cell.initCell(groups: privateGroupData)
+            cell.firstCellView.delegate = self
+            cell.secondCellView.delegate = self
+            return cell
+        case publicGroupCollectionView:
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: HomePublicGroupCollectionViewCell.CellIdentifier, for: indexPath) as? HomePublicGroupCollectionViewCell else { return UICollectionViewCell() }
+            cell.initCell(group: publicGroupData[indexPath.item])
+            return cell
+        default:
+            return UICollectionViewCell()
+        }
     }
 }

--- a/ThunderRing/ThunderRing/Sources/Home/Views/HomeHeaderView.swift
+++ b/ThunderRing/ThunderRing/Sources/Home/Views/HomeHeaderView.swift
@@ -1,0 +1,112 @@
+//
+//  HomeHeaderView.swift
+//  ThunderRing
+//
+//  Created by 소연 on 2022/03/08.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class HomeHeaderView: UIView {
+    
+    var title = "" {
+        didSet { titleLabel.text = title }
+    }
+    
+    var count = 0 {
+        didSet { }
+    }
+    
+    var isMoreEnabled = true {
+        didSet { moreButton.isHidden = isMoreEnabled }
+    }
+
+    private lazy var titleLabel = UILabel().then {
+        $0.textColor = .gray100
+        $0.font = .SpoqaHanSansNeo(type: .bold, size: 18)
+    }
+    
+    private lazy var countLabel = UILabel().then {
+        $0.textColor = .gray200
+        $0.font = .DINPro(type: .regular, size: 18)
+    }
+
+    private lazy var moreButton = MoreButton()
+    
+    init() {
+        super.init(frame: .zero)
+        configUI()
+        setLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func configUI() {
+        addSubviews([titleLabel, countLabel, moreButton])
+    }
+    
+    private func setLayout() {
+        titleLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(25)
+            $0.top.equalToSuperview().inset(27)
+        }
+        
+        countLabel.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.top)
+            $0.leading.equalTo(titleLabel.snp.trailing).offset(6)
+        }
+
+        moreButton.snp.makeConstraints {
+            $0.centerY.equalTo(titleLabel.snp.centerY)
+            $0.trailing.equalToSuperview().inset(25)
+            $0.width.equalTo(75)
+            $0.height.equalTo(28)
+        }
+    }
+}
+
+// MARK: - All Button
+
+fileprivate final class MoreButton: UIButton {
+    
+    // MARK: - Properties
+    
+    private lazy var textLabel = UILabel().then {
+        $0.font = .SpoqaHanSansNeo(type: .medium, size: 12)
+        $0.text = "전체보기"
+        $0.textColor = .gray100
+        $0.backgroundColor = .background
+        $0.textAlignment = .center
+    }
+
+    // MARK: - Initializers
+    
+    init() {
+        super.init(frame: .zero)
+        setButton()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - InitUI
+    
+    private func setButton() {
+        self.layer.borderColor = UIColor.gray100.cgColor
+        self.layer.borderWidth = 1
+        
+        self.makeRounded(cornerRadius: 14)
+        
+        addSubview(textLabel)
+        textLabel.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalToSuperview().inset(6)
+        }
+    }
+}

--- a/ThunderRing/ThunderRing/Sources/Home/Views/HomePrivateGroupCollectionViewCell.swift
+++ b/ThunderRing/ThunderRing/Sources/Home/Views/HomePrivateGroupCollectionViewCell.swift
@@ -15,11 +15,11 @@ final class HomePrivateGroupCollectionViewCell: UICollectionViewCell {
     
     // MARK: - Properties
     
-    private lazy var firstCellView = HomePrivateGroupCollectionViewCellView()
+    var firstCellView = HomePrivateGroupCollectionViewCellView()
     private lazy var lineView = UIView().then {
         $0.backgroundColor = .gray350
     }
-    private lazy var secondCellView = HomePrivateGroupCollectionViewCellView()
+    var secondCellView = HomePrivateGroupCollectionViewCellView()
     
     // MARK: - Initializer
     
@@ -38,8 +38,14 @@ final class HomePrivateGroupCollectionViewCell: UICollectionViewCell {
     private func configUI() {
         backgroundColor = .background
         
-        addSubviews([firstCellView, lineView, secondCellView])
-        
+        contentView.addSubview(firstCellView)
+        contentView.addSubview(lineView)
+        contentView.addSubview(secondCellView)
+
+        contentView.initViewBorder(borderWidth: 1,
+                                   borderColor: UIColor.gray350.cgColor,
+                                   cornerRadius: 5,
+                                   bounds: true)
         lineView.makeRounded(cornerRadius: 0.5)
     }
     
@@ -50,8 +56,8 @@ final class HomePrivateGroupCollectionViewCell: UICollectionViewCell {
         }
         
         lineView.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(12)
-            $0.top.equalTo(firstCellView.snp.bottom)
+            $0.centerY.equalToSuperview()
+            $0.leading.trailing.equalToSuperview().inset(11)
             $0.height.equalTo(1)
         }
         
@@ -60,6 +66,13 @@ final class HomePrivateGroupCollectionViewCell: UICollectionViewCell {
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(147)
         }
+    }
+    
+    // MARK: - Public Method
+    
+    func initCell(groups: [PrivateGroupDataModel]) {
+        firstCellView.configCell(group: groups[0])
+        secondCellView.configCell(group: groups[1])
     }
 }
 

--- a/ThunderRing/ThunderRing/Sources/Home/Views/HomePrivateGroupCollectionViewCellView.swift
+++ b/ThunderRing/ThunderRing/Sources/Home/Views/HomePrivateGroupCollectionViewCellView.swift
@@ -19,31 +19,35 @@ final class HomePrivateGroupCollectionViewCellView: UIView {
     
     // MARK: - Properties
     
-    private lazy var groupImageView = UIImageView().then {
+    private var groupImageView = UIImageView().then {
         $0.image = UIImage(named: "imgJuju")
         $0.contentMode = .scaleAspectFill
     }
     
-    private lazy var titleLabel = UILabel().then {
+    private var groupNameLabel = UILabel().then {
         $0.text = "그룹이름"
         $0.textColor = .black
         $0.font = .SpoqaHanSansNeo(type: .medium, size: 17)
     }
     
-    private lazy var memberCountLabel = UILabel().then {
+    private var memberCountLabel = UILabel().then {
         $0.text = "0"
         $0.textColor = .gray150
         $0.font = .SpoqaHanSansNeo(type: .regular, size: 15)
     }
     
-    private lazy var subTitleLabel = UILabel().then {
+    private var descriptionLabel = UILabel().then {
         $0.text = "그룹상세설명"
         $0.textColor = .gray150
         $0.font = .SpoqaHanSansNeo(type: .regular, size: 13)
     }
     
-    private lazy var enterButton = ItemButton(buttonType: .enter)
-    private lazy var lightningButton = ItemButton(buttonType: .lightning)
+    private var enterButton = ItemButton(buttonType: .enter).then {
+        $0.addTarget(self, action: #selector(touchUpEnterButton), for: .touchUpInside)
+    }
+    private var lightningButton = ItemButton(buttonType: .lightning).then {
+        $0.addTarget(self, action: #selector(touchUpLightningButton), for: .touchUpInside)
+    }
     
     weak var delegate: HomePrivateGroupCollectionViewCellViewDelegate?
     
@@ -63,41 +67,52 @@ final class HomePrivateGroupCollectionViewCellView: UIView {
     
     private func configUI() {
         self.backgroundColor = .background
-        addSubviews([groupImageView, titleLabel, subTitleLabel, enterButton, lightningButton])
+        
+        self.addSubviews([groupImageView,
+                          groupNameLabel,
+                          descriptionLabel,
+                          memberCountLabel,
+                          enterButton,
+                          lightningButton])
         
         groupImageView.makeRounded(cornerRadius: 25)
     }
     
-    // FIXME: - 레이아웃 값 수정
     private func setLayout() {
         groupImageView.snp.makeConstraints {
             $0.centerY.equalToSuperview()
             $0.leading.equalToSuperview().inset(18)
+            $0.width.equalTo(80)
+            $0.height.equalTo(82)
         }
         
-        titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(32)
-            $0.leading.equalTo(groupImageView.snp.trailing).offset(19)
+        groupNameLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(30)
+            $0.leading.equalTo(groupImageView.snp.trailing).offset(17)
         }
         
         memberCountLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(33)
-            $0.leading.equalTo(titleLabel.snp.trailing).offset(4)
+            $0.top.equalToSuperview().inset(31)
+            $0.leading.equalTo(groupNameLabel.snp.trailing).offset(4)
         }
         
-        subTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(5)
+        descriptionLabel.snp.makeConstraints {
+            $0.top.equalTo(groupNameLabel.snp.bottom).offset(5)
             $0.leading.equalTo(groupImageView.snp.trailing).offset(19)
         }
         
         enterButton.snp.makeConstraints {
-            $0.top.equalTo(subTitleLabel.snp.bottom).offset(12)
-            $0.leading.trailing.equalTo(groupImageView.snp.trailing).offset(19)
+            $0.top.equalTo(descriptionLabel.snp.bottom).offset(10)
+            $0.leading.equalTo(groupImageView.snp.trailing).offset(17)
+            $0.width.equalTo(80)
+            $0.height.equalTo(30)
         }
-        
+
         lightningButton.snp.makeConstraints {
-            $0.top.equalTo(subTitleLabel.snp.bottom).offset(12)
+            $0.top.equalTo(descriptionLabel.snp.bottom).offset(12)
             $0.leading.equalTo(enterButton.snp.trailing).offset(7)
+            $0.width.equalTo(80)
+            $0.height.equalTo(30)
         }
     }
     
@@ -109,6 +124,19 @@ final class HomePrivateGroupCollectionViewCellView: UIView {
     
     @objc func touchUpLightningButton() {
         delegate?.touchUpLightningButton()
+    }
+    
+    // MARK: - Public Method
+    
+    func configCell(group: PrivateGroupDataModel) {
+        guard let image = group.groupImageName else { return }
+        groupImageView.image = UIImage(named: image)
+        
+        groupNameLabel.text = group.groupName
+        
+        memberCountLabel.text = "\(group.memberCounts)"
+        
+        descriptionLabel.text = group.groupDescription
     }
 }
 
@@ -153,7 +181,6 @@ fileprivate final class ItemButton: UIButton {
         $0.font = .SpoqaHanSansNeo(type: .regular, size: 14)
         $0.text = type.title
         $0.textColor = type.textColor
-        $0.backgroundColor = type.backgroundColor
         $0.textAlignment = .center
     }
 
@@ -169,7 +196,10 @@ fileprivate final class ItemButton: UIButton {
 
     private func setButton() {
         self.makeRounded(cornerRadius: 14)
-        addSubview(textLabel)
+        self.backgroundColor = type.backgroundColor
+        self.layer.borderWidth = 1
+        self.layer.borderColor = UIColor.purple100.cgColor
+        self.addSubview(textLabel)
         textLabel.snp.makeConstraints {
             $0.centerX.centerY.equalToSuperview()
         }

--- a/ThunderRing/ThunderRing/Sources/Home/Views/HomePublicGroupCollectionViewCell.swift
+++ b/ThunderRing/ThunderRing/Sources/Home/Views/HomePublicGroupCollectionViewCell.swift
@@ -11,6 +11,7 @@ import SnapKit
 import Then
 
 final class HomePublicGroupCollectionViewCell: UICollectionViewCell {
+    static var CellIdentifier: String { return String(describing: self) }
     
     // MARK: - Properties
     
@@ -31,14 +32,19 @@ final class HomePublicGroupCollectionViewCell: UICollectionViewCell {
     // MARK: - InitUI
     
     private func configUI() {
-        self.backgroundColor = .background
-        addSubview(cellView)
+        backgroundColor = .background
+        contentView.addSubview(cellView)
+        contentView.initViewBorder(borderWidth: 1, borderColor: UIColor.gray350.cgColor, cornerRadius: 5, bounds: true)
     }
     
     private func setLayout() {
         cellView.snp.makeConstraints {
             $0.leading.trailing.top.bottom.equalToSuperview()
         }
+    }
+    
+    func initCell(group: PublicGroupDataModel) {
+        cellView.configCell(group: group)
     }
 }
 

--- a/ThunderRing/ThunderRing/Sources/Home/Views/HomePublicGroupCollectionViewCellView.swift
+++ b/ThunderRing/ThunderRing/Sources/Home/Views/HomePublicGroupCollectionViewCellView.swift
@@ -19,7 +19,7 @@ final class HomePublicGroupCollectionViewCellView: UIView {
         $0.contentMode = .scaleAspectFill
     }
     
-    private lazy var titleLabel = UILabel().then {
+    private lazy var groupNameLabel = UILabel().then {
         $0.text = "그룹이름"
         $0.textColor = .black
         $0.font = .SpoqaHanSansNeo(type: .medium, size: 17)
@@ -31,11 +31,11 @@ final class HomePublicGroupCollectionViewCellView: UIView {
         $0.font = .SpoqaHanSansNeo(type: .regular, size: 15)
     }
     
-    private lazy var subTitleLabel = UILabel().then {
-        $0.text = "그룹상세설명"
-        $0.textColor = .gray150
-        $0.font = .SpoqaHanSansNeo(type: .regular, size: 13)
+    private lazy var tagImageView = UIImageView().then {
+        $0.contentMode = .scaleAspectFit
     }
+    
+    private var lightningButton = LightningButton()
     
     // MARK: - Initializer
     
@@ -52,50 +52,99 @@ final class HomePublicGroupCollectionViewCellView: UIView {
     // MARK: - InitUI
     
     private func configUI() {
+        addSubviews([groupImageView,
+                     groupNameLabel,
+                     memberCountLabel,
+                     tagImageView,
+                     lightningButton])
         
+        groupImageView.makeRounded(cornerRadius: 23)
+        
+        lightningButton.makeRounded(cornerRadius: 15)
     }
     
     private func setLayout() {
+        groupImageView.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(22)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(74)
+            $0.height.equalTo(74)
+        }
         
-    }
-}
-
-// MARK: - Label
-
-fileprivate enum GroupType {
-    case cozy
-    case crowd
-    case diligent
-    case emotion
-    case soft
-    
-    var title: String {
-        switch self {
-        case .cozy:
-            return "#포근한 해질녘"
-        case .crowd:
-            return "#북적이는 오후"
-        case .diligent:
-            return "부지런한 동틀녘"
-        case .emotion:
-            return "감성적인 새벽녘"
-        case .soft:
-            return "사근한 오전"
+        groupNameLabel.snp.makeConstraints {
+            $0.top.equalTo(groupImageView.snp.bottom).offset(14)
+            $0.leading.equalToSuperview().inset(30)
+        }
+        
+        memberCountLabel.snp.makeConstraints {
+            $0.bottom.equalTo(groupNameLabel.snp.bottom)
+            $0.leading.equalTo(groupNameLabel.snp.trailing).offset(4)
+        }
+        
+        tagImageView.snp.makeConstraints {
+            $0.top.equalTo(memberCountLabel.snp.bottom).offset(6)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(21)
+        }
+        
+        lightningButton.snp.makeConstraints {
+            $0.top.equalTo(tagImageView.snp.bottom).offset(15)
+            $0.width.equalTo(88)
+            $0.height.equalTo(30)
+            $0.centerX.equalToSuperview()
         }
     }
     
-    var color: UIColor {
-        switch self {
-        case .cozy:
-            return UIColor.cozyColor
-        case .crowd:
-            return UIColor.crowdColor
+    // MARK: - Public Method
+    
+    func configCell(group: PublicGroupDataModel) {
+        groupImageView.image = UIImage(named: group.groupImage)
+        
+        groupNameLabel.text = group.groupName
+        
+        memberCountLabel.text = "\(group.memberCounts)/\(group.memberTotalCounts!)"
+        
+        switch group.publicGroupType {
         case .diligent:
-            return UIColor.diligentColor
+            tagImageView.image = UIImage(named: "tagDiligent")
+        case .crowd:
+            tagImageView.image = UIImage(named: "tagCrowd")
         case .emotion:
-            return UIColor.emotionColor
+            tagImageView.image = UIImage(named: "tagEmotion")
         case .soft:
-            return UIColor.softColor
+            tagImageView.image = UIImage(named: "tagSoft")
+        case .cozy:
+            tagImageView.image = UIImage(named: "tagCozy")
+        }
+        tagImageView.contentMode = .scaleAspectFit
+    }
+}
+
+// MARK: - Custom Button
+
+fileprivate final class LightningButton: UIButton {
+    private lazy var textLabel = UILabel().then {
+        $0.text = "번개"
+        $0.font = .SpoqaHanSansNeo(type: .regular, size: 14)
+        $0.textColor = .white
+        $0.textAlignment = .center
+    }
+
+    init() {
+        super.init(frame: .zero)
+        setButton()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setButton() {
+        self.makeRounded(cornerRadius: 14)
+        self.backgroundColor = .purple100
+        self.addSubview(textLabel)
+        textLabel.snp.makeConstraints {
+            $0.centerX.centerY.equalToSuperview()
         }
     }
 }

--- a/ThunderRing/ThunderRing/Sources/Lightning/Models/PublicGroupDataModel.swift
+++ b/ThunderRing/ThunderRing/Sources/Lightning/Models/PublicGroupDataModel.swift
@@ -29,6 +29,7 @@ var publicGroupData : [PublicGroupDataModel] = [
     PublicGroupDataModel(groupImage: "imgFlog", groupName: "서울숲 플로깅", memberCounts: 4, publicGroupType: .diligent, memberTotalCounts: 100, description: "같이 깨끗한 지구 만들어요"),
     PublicGroupDataModel(groupImage: "imgFive", groupName: "05년생 모여", memberCounts: 7, publicGroupType: .crowd, memberTotalCounts: 10, description: "개그에 자신 있으신 분"),
     PublicGroupDataModel(groupImage: "imgStudent", groupName: "서울중학교", memberCounts: 4, publicGroupType: .cozy, memberTotalCounts: 300, description: "서울중 동창 모여라"),
+    PublicGroupDataModel(groupImage: "imgGame", groupName: "닌텐도 할 사람", memberCounts: 3, publicGroupType: .soft, memberTotalCounts: 30, description: "고수만 들어오삼"),
     PublicGroupDataModel(groupImage: "imgGame", groupName: "닌텐도 할 사람", memberCounts: 3, publicGroupType: .soft, memberTotalCounts: 30, description: "고수만 들어오삼")
 ]
 


### PR DESCRIPTION
### 관련 이슈
#75 

### 구현/변경 사항 및 이유
- 수정된 UI로 홈 화면 UI 구현 
- 수정된 뷰로 이동할 수 있도록 화면 연결
- 공개그룹 데이터 4개에서 5개로 변경 

### PR Point
그룹의 수에 따라서 화면의 길이가 길어지고, 이를 동적으로 바로 뷰에 나타내기 위해 UIStackView를 UIScrollView 안에 넣었습니다.

### 참고사항
비공개그룹의 경우, 홀수일 경우에 따른 분기처리를 마무리 하지 않았습니다. (뷰가 아직 확정되지 않았기 때문에)
